### PR TITLE
fix(ci): ensure setuptools for liccheck

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -42,6 +42,8 @@ runs:
         cache: ${{ inputs.cache }}
     - name: Install dependencies
       run: |
+        python -m pip install --upgrade setuptools
+
         if [ "${{ inputs.install-superset }}" = "true" ]; then
           sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
 


### PR DESCRIPTION
Fix the Helm lint dependency-review job when install-superset is false.\n\nliccheck imports pkg_resources, which comes from setuptools. The shared setup action only installed setuptools when Superset itself was being installed, so the helm-lint workflow ended up without pkg_resources and failed before running chart checks.\n\nThis makes setuptools available unconditionally while keeping the Superset install gated.