### PR TITLE
fix: IT-130 Superset outputs processor name mismatch

### DIFF
--- a/.apolo/src/apolo_apps_superset/__init__.py
+++ b/.apolo/src/apolo_apps_superset/__init__.py
@@ -2,7 +2,7 @@ from apolo_apps_superset.inputs_processor import (
     SupersetInputsProcessor,
 )
 from apolo_apps_superset.outputs_processor import (
-    SupersetOutputProcessor,
+    SupersetOutputsProcessor,
 )
 from apolo_apps_superset.types import (
     SupersetInputs,
@@ -11,7 +11,7 @@ from apolo_apps_superset.types import (
 
 __all__ = [
     "SupersetInputsProcessor",
-    "SupersetOutputProcessor",
+    "SupersetOutputsProcessor",
     "SupersetInputs",
     "SupersetOutputs",
 ]

--- a/.apolo/src/apolo_apps_superset/outputs_processor.py
+++ b/.apolo/src/apolo_apps_superset/outputs_processor.py
@@ -52,7 +52,7 @@ async def get_superset_outputs(
     )
 
 
-class SupersetOutputProcessor(BaseAppOutputsProcessor[SupersetOutputs]):
+class SupersetOutputsProcessor(BaseAppOutputsProcessor[SupersetOutputs]):
     async def _generate_outputs(
         self,
         helm_values: dict[str, t.Any],

--- a/.apolo/tests/unit/test_processor_discovery.py
+++ b/.apolo/tests/unit/test_processor_discovery.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import yaml
+from apolo_app_types.outputs.utils.discovery import (
+    load_app_postprocessor,
+    load_app_preprocessor,
+)
+
+
+APPLICATIONS_YAML = Path(__file__).resolve().parents[2] / "applications.yaml"
+
+
+def _superset_app() -> dict:
+    apps = yaml.safe_load(APPLICATIONS_YAML.read_text())
+    return next(app for app in apps if app["app_type"] == "superset")
+
+
+def test_input_processor_name_matches_code() -> None:
+    app = _superset_app()
+    loaded = load_app_preprocessor(
+        app["app_type"],
+        app["app_package_name"],
+        app["inputs"]["processor"],
+    )
+    assert loaded is not None, (
+        f"inputs.processor {app['inputs']['processor']!r} in applications.yaml "
+        f"is not a class in {app['app_package_name']}"
+    )
+
+
+def test_output_processor_name_matches_code() -> None:
+    app = _superset_app()
+    loaded = load_app_postprocessor(
+        app["app_type"],
+        app["app_package_name"],
+        app["outputs"]["processor"],
+    )
+    assert loaded is not None, (
+        f"outputs.processor {app['outputs']['processor']!r} in applications.yaml "
+        f"is not a class in {app['app_package_name']}"
+    )


### PR DESCRIPTION
## Problem
A healthy Superset app produced **no outputs**, so the Console showed **no "Open App" button** and the web URL was undiscoverable (IT-130).

## Root cause
`.apolo/applications.yaml` declares:
```yaml
outputs:
  processor: SupersetOutputsProcessor
```
but the class was named `SupersetOutputProcessor` (missing the `s`). The platform's post-install hook resolves the postprocessor by that exact name via `load_app_postprocessor(..., exact_type_name="SupersetOutputsProcessor")`, which filters classes by `name == exact_type_name`. No class matched → `None` → the `update-outputs` step generated nothing. The workload still ran, so the app reported `healthy` with empty outputs.

## Fix
- Rename `SupersetOutputProcessor` → `SupersetOutputsProcessor` (class + `__init__` export) to match `applications.yaml`, the `BaseAppOutputsProcessor` base, and the existing `SupersetInputsProcessor` convention.
- Add `test_processor_discovery.py`: reads `applications.yaml` and asserts both the inputs and outputs processor names actually resolve through the same discovery loaders the platform uses — so a name mismatch fails CI.

## Verification
- Reproduced the resolution locally: with the applications.yaml name, `load_app_postprocessor` returned `None` before and the class after.
- mypy clean; unit tests 6/6 (4 existing + 2 new).
- Follow-up: will confirm on dev by installing this branch's template version and checking that outputs / Open App appear.

Related: IT-85.